### PR TITLE
Use ropes for stringifiers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "cranelift-native",
  "lazy_static",
  "regex",
+ "ropey",
 ]
 
 [[package]]
@@ -222,6 +223,15 @@ dependencies = [
  "libc",
  "mach",
  "winapi",
+]
+
+[[package]]
+name = "ropey"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b9aa65bcd9f308d37c7158b4a1afaaa32b8450213e20c9b98e7d5b3cc2fec3"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ cranelift = "0.80.0"
 cranelift-jit = "0.80.0"
 cranelift-module = "0.80.0"
 cranelift-native = "0.80.0"
+ropey = "1.3"
 
 [profile.dev]
 # opt-level = 0


### PR DESCRIPTION
Tbh, I'm not sure this would be faster than the previous implementation, since there's now conversions occurring between strings and ropes. I think it could probably be made faster if the amount of conversions are minimised and if all the interpolations are only done with ropes, and conversion to strings only happens once after these are done. Alternatively, maybe we shouldn't rely on the `Display` trait and `write` macro for interpolation?